### PR TITLE
SSL 일경우 통신 에러시 발생하는 부분을 일반 TCP와 동일하게 처리

### DIFF
--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -610,9 +610,11 @@ human_readable_mqtt_version(4) ->
 human_readable_mqtt_version(_) ->
     "N/A".
 
-send_client(Frame, #proc_state{ socket = Sock }) ->
-    %rabbit_log:info("MQTT sending frame ~p ~n", [Frame]),
-    rabbit_net:port_command(Sock, rabbit_mqtt_frame:serialise(Frame)).
+send_client(Frame, PState = #proc_state{ socket = Sock }) ->
+    try rabbit_net:port_command(Sock, rabbit_mqtt_frame:serialise(Frame))
+    catch
+        error:Reason -> self() ! {inet_async, Sock, {error, Reason}}
+    end.
 
 close_connection(PState = #proc_state{ connection = undefined }) ->
     PState;

--- a/src/rabbit_mqtt_retained_msg_store_mnesia.erl
+++ b/src/rabbit_mqtt_retained_msg_store_mnesia.erl
@@ -44,8 +44,8 @@ new(_, _) ->
 
 recover(_, _) ->
   case lists:member(retained_message,mnesia:system_info(tables)) of
-      true -> rabbit_log:info("recover(_, _) true"),{ok, "already exist"};
-      false -> rabbit_log:info("recover(_, _) false"),{error, uninitialized}
+      true -> {ok, "already exist"};
+      false -> {error, uninitialized}
   end.
 
 insert(Topic, Msg, _) ->


### PR DESCRIPTION
SSL 통신에러시 아래와 같은 메세지로 termination됨

** Reason for termination == 
** {closed,[{rabbit_net,port_command,2,
                        [{file,"src/rabbit_net.erl"},{line,143}]},
            {rabbit_mqtt_processor,process_request,3,
                                   [{file,"src/rabbit_mqtt_processor.erl"},
                                    {line,224}]},
            {rabbit_mqtt_reader,process_received_bytes,2,
                                [{file,"src/rabbit_mqtt_reader.erl"},
                                 {line,221}]},
            {gen_server2,handle_msg,2,
                         [{file,"src/gen_server2.erl"},{line,1049}]},
            {proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,250}]}]}

실제로 rabbit_net:port_command 에서 SSL과 일반 TCP실패일때 동작이 다름
SSL일때는 error를 throw하고 TCP일때는 elrang:port_command기본동작을 한다.

error를 catch하여 erlang:port_command와 동일하게 에러처리 하도록 변경한다.
그래서 기존 handle_info에서 에러 처리하는 로직을 그대로 사용하게 한다. 