### PR TITLE
ssl disconnection시 send message 수정

### DIFF
--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -613,7 +613,7 @@ human_readable_mqtt_version(_) ->
 send_client(Frame, PState = #proc_state{ socket = Sock }) ->
     try rabbit_net:port_command(Sock, rabbit_mqtt_frame:serialise(Frame))
     catch
-        error:Reason -> self() ! {inet_async, Sock, {error, Reason}}
+        error:Reason -> self() ! {inet_reply, Sock, {error, Reason}}
     end.
 
 close_connection(PState = #proc_state{ connection = undefined }) ->


### PR DESCRIPTION
기존에 테스트가 어떻게 통과했는지 모르겠네요 ㅡㅡ

2번째 handle_info를 사용하도록 변경함. 

1: handle_info({inet_async, _Sock, _Ref, {error, Reason}}, State = #state {}) ->
    network_error(Reason, State);

2: handle_info({inet_reply, _Sock, {error, Reason}}, State = #state {}) ->
    network_error(Reason, State);

** Reason for termination == 
** {mqtt_unexpected_msg,
       {inet_async,
           {ssl_socket,#Port<0.594756>,
               {sslsocket,
                   {gen_tcp,#Port<0.594756>,tls_connection,undefined},
                   <0.23413.108>}},
           {error,closed}}}
