### PR TITLE
check duplicate_id for cluster

### DIFF
--- a/src/rabbit_mqtt_collector.erl
+++ b/src/rabbit_mqtt_collector.erl
@@ -33,6 +33,9 @@ start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
 register(ClientId, Pid) ->
+    gen_server:abcast(rabbit_mqtt_util:get_running_nodes(),
+                      rabbit_mqtt_collector,
+                      {register, ClientId}),
     gen_server:call(rabbit_mqtt_collector, {register, ClientId, Pid}, infinity).
 
 unregister(ClientId, Pid) ->
@@ -44,6 +47,7 @@ init([]) ->
     {ok, #state{client_ids = dict:new()}}. % clientid -> {pid, monitor}
 
 %%--------------------------------------------------------------------------
+
 
 handle_call({register, ClientId, Pid}, _From,
             State = #state{client_ids = Ids}) ->
@@ -68,6 +72,18 @@ handle_call({unregister, ClientId, Pid}, _From, State = #state{client_ids = Ids}
 
 handle_call(Msg, _From, State) ->
     {stop, {unhandled_call, Msg}, State}.
+
+handle_cast({register, ClientId}, 
+            State = #state{client_ids = Ids}) ->
+    Ids1 = case dict:find(ClientId, Ids) of
+               {ok, {OldPid, MRef}} ->
+                   catch gen_server2:cast(OldPid, duplicate_id),
+                   erlang:demonitor(MRef),
+                   dict:erase(ClientId, Ids);
+               error ->
+                   Ids
+           end,
+    {noreply, State#state{client_ids = Ids1}};
 
 handle_cast(Msg, State) ->
     {stop, {unhandled_cast, Msg}, State}.

--- a/src/rabbit_mqtt_reader.erl
+++ b/src/rabbit_mqtt_reader.erl
@@ -203,13 +203,18 @@ terminate({network_error, Reason}, _State) ->
 
 terminate(normal, #state{proc_state = ProcState,
                          conn_name  = ConnName}) ->
-    rabbit_mqtt_processor:close_connection(ProcState),
+    rabbit_mqtt_processor:close_connection_and_relay(ProcState),
     log(info, "closing MQTT connection ~p (~s)~n", [self(), ConnName]),
     ok;
 
 terminate(Reason, #state{proc_state = ProcState,
                           conn_name  = ConnName}) ->
-    rabbit_mqtt_processor:close_connection(ProcState),
+    case Reason of
+        {shutdown,duplicate_id} ->
+            rabbit_mqtt_processor:close_connection(ProcState);
+        _ ->
+            rabbit_mqtt_processor:close_connection_and_relay(ProcState)
+    end,
     log(error, "closing MQTT connection ~p (~s) Reason:~p ~n", [self(), ConnName, Reason]),
     ok.
 

--- a/src/rabbit_mqtt_util.erl
+++ b/src/rabbit_mqtt_util.erl
@@ -17,6 +17,7 @@
 -module(rabbit_mqtt_util).
 
 -include("rabbit_mqtt.hrl").
+-include_lib("rabbit_common/include/rabbit.hrl").
 
 -compile(export_all).
 
@@ -96,4 +97,10 @@ http_get(Path, Request, HTTPOptions) ->
     HostHdr = rabbit_misc:format("~s:~b", [Host, Port]),
     httpc:request(get, {GET_URI, [{"Host", HostHdr}]}, HTTPOptions, []).
 
-
+get_running_nodes() ->
+    S = rabbit_mnesia:status(),
+    Running = proplists:get_value(running_nodes, S),
+    lists:filter(fun (Node) 
+                    when Node =:= node() -> false;
+                    (_) -> true
+                 end, Running).

--- a/src/rabbitmq_mqtt.app.src
+++ b/src/rabbitmq_mqtt.app.src
@@ -26,4 +26,4 @@
                                       {conn_timeout, 1000},
                                       {timeout, 3000}]},
          {connection_idle_timeout, 5000}]},
-  {applications, [kernel, stdlib, rabbit, amqp_client]}]}.
+  {applications, [kernel, stdlib, rabbit, amqp_client, mochiweb]}]}.


### PR DESCRIPTION
1. Check the duplicate ID in cluster env.
2. Don't relay when duplicated ID.

클러스터에서 ID중복 원리.
ID중복되었을때 신규 커낵션 유지하고 기존 커낵션을 삭제한다.
그러므로 다른 노드에게 그대로 알려주고 기존 커낵션이 존재하면 종료처리 한다.

* 주의점 
다른 노드에서 MQTT버젼이 다르면 unhandled_cast가 발생하여 서비스에 영향을 미친다.
서비스 중인 장비는 두번 나누어 배포해야 되고 서비스 중이지 않은 장비는 전부 종료후 배포한다.