### PR TITLE
Improve mqtt_collector unregister part.

### DIFF
--- a/src/rabbit_mqtt_collector.erl
+++ b/src/rabbit_mqtt_collector.erl
@@ -61,9 +61,8 @@ handle_call({register, ClientId, Pid}, _From,
                error ->
                    Ids
            end,
-    Ids2 = dict:store(ClientId, {Pid, erlang:monitor(process, Pid)}, Ids1),
-    Pids2 = dict:store(Pid, ClientId, Pids),
-    {reply, ok, State#state{client_ids = Ids2, pids = Pids2}};
+    {reply, ok, State#state{client_ids = dict:store(ClientId, {Pid, erlang:monitor(process, Pid)}, Ids1), 
+                            pids = dict:store(Pid, ClientId, Pids)}};
 
 handle_call({unregister, ClientId, Pid}, _From, State = #state{client_ids = Ids, pids = Pids}) ->
     {Reply, Ids1} = case dict:find(ClientId, Ids) of

--- a/src/rabbit_mqtt_processor.erl
+++ b/src/rabbit_mqtt_processor.erl
@@ -219,8 +219,6 @@ process_request(?SUBSCRIBE,
                             PState1 #proc_state{subscriptions =
                                                 dict:append(TopicName, SupportedQos, Subs)}}
                        end, {[], PState0}, Topics),
-        #proc_state{subscriptions = Subscriptions} = PState1,
-        rabbit_log:log(mqtt_packet, debug, "~w ~1024p", [self(), Subscriptions]),
         SendFun(#mqtt_frame{fixed    = #mqtt_frame_fixed{type = ?SUBACK},
                             variable = #mqtt_frame_suback{
                                         message_id = MessageId,


### PR DESCRIPTION
When monitoring process is downed, unregister clientId.

dict:filter -> dict:find